### PR TITLE
feat(folderReader): add folderReader logics

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,8 +1,10 @@
 "use strict";
 
-import { app, protocol, BrowserWindow } from "electron";
+import { app, protocol, BrowserWindow, ipcMain } from "electron";
 import { createProtocol } from "vue-cli-plugin-electron-builder/lib";
 import installExtension, { VUEJS3_DEVTOOLS } from "electron-devtools-installer";
+import FolderReader from "./services/folderReader";
+
 const isDevelopment = process.env.NODE_ENV !== "production";
 
 // Scheme must be registered before the app is ready
@@ -32,6 +34,18 @@ async function createWindow() {
     // Load the index.html when not in development
     win.loadURL("app://./index.html");
   }
+
+  ipcMain.on("getFolderPath-event", (event) => {
+    const folderReader = new FolderReader(win);
+    folderReader
+      .getFolderPath()
+      .then((res) => {
+        event.reply("getFolderPath-reply", res);
+      })
+      .catch((error) => {
+        event.reply("getFolderPath-reply", error);
+      });
+  });
 }
 
 // Quit when all windows are closed.

--- a/src/background.js
+++ b/src/background.js
@@ -39,8 +39,8 @@ async function createWindow() {
     const folderReader = new FolderReader(win);
     folderReader
       .getFolderPath()
-      .then((res) => {
-        event.reply("getFolderPath-reply", res);
+      .then((path) => {
+        event.reply("getFolderPath-reply", path);
       })
       .catch((error) => {
         event.reply("getFolderPath-reply", error);

--- a/src/services/folderReader.js
+++ b/src/services/folderReader.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const { dialog } = require("electron");
+import { access } from "fs/promises";
+
+class folderReader {
+  constructor(electronWindow) {
+    this.window = electronWindow;
+    this.options = {
+      title: "Choose a github project",
+      defaultPath: "D:\\electron-app",
+      buttonLabel: "Select this folder",
+      filters: [{ name: "All Files", extensions: ["*"] }],
+      properties: ["openDirectory"],
+    };
+  }
+
+  getFolderPath() {
+    let folderPath = dialog.showOpenDialog(this.window, this.options);
+    return folderPath.then((res) => {
+      return this.checkIsGitFolder(res.filePaths);
+    });
+  }
+
+  checkIsGitFolder(folderPath) {
+    return access(`${folderPath}/.git`)
+      .then(() => {
+        return folderPath;
+      })
+      .catch(() => {
+        return "This folder does not contain a git folder";
+      });
+  }
+}
+export default folderReader;

--- a/src/services/folderReader.js
+++ b/src/services/folderReader.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { dialog } = require("electron");
+import { dialog } from "electron";
 import { access } from "fs/promises";
 
 class folderReader {


### PR DESCRIPTION
This PR set : 
- Listen event from the front on the back
- FolderReader logics 
- Send response to the front

FolderReader logics contain : 
- getFolderPath() => Open a dialog and call checkIsGitFolder() with folderPath selected by the user
- checkIsGitFolder() => return if folderPath have .git or not 